### PR TITLE
Fix confusion matrix title

### DIFF
--- a/WhatIsML.ipynb
+++ b/WhatIsML.ipynb
@@ -543,7 +543,7 @@
    "outputs": [],
    "source": [
     "cm = confusion_matrix(y_true, y_pred, labels=labels)\n",
-    "print(\"Confusion Matrix (predict/actual):\\n\", \n",
+    "print(\"Confusion Matrix (actual/predict):\\n\", \n",
     "      pd.DataFrame(cm, index=labels, columns=labels), sep=\"\")\n",
     "\n",
     "recall = np.diag(cm) / np.sum(cm, axis=1)\n",


### PR DESCRIPTION
If I read the docs for confusion_matrix correctly, rows represent the actual group of an observation, whereas columns represent the prediction.
> By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
    is equal to the number of observations known to be in group :math:`i` but
    predicted to be in group :math:`j`.