### PR TITLE
Fix as per training

### DIFF
--- a/FeatureExpansion.ipynb
+++ b/FeatureExpansion.ipynb
@@ -444,7 +444,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = linf.drop('TARGET', axis=1)\n",
+    "X = linf.drop(['TARGET','f1xf2'], axis=1)\n",
     "y = linf['TARGET']\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, y)"
    ]
@@ -457,7 +457,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9998585539211453"
+       "0.946328322648356"
       ]
      },
      "execution_count": 11,
@@ -480,7 +480,7 @@
     {
      "data": {
       "text/plain": [
-       "0.975119339128057"
+       "0.9545864808062933"
       ]
      },
      "execution_count": 12,


### PR DESCRIPTION
Hello @DavidMertz, As per the description in the online training and the information in the notebook cells 10,11 and 12 showcase certain regressors manage to derive the synthetic feature through their algorithmic structure. And they work decently even without the added feature "f1xf2".
I am attempting to fix this as per my understanding. Please review. Thank you!