### PR TITLE
[pd].str.replace() fails if `regex=True` not specified

### DIFF
--- a/Exploring.ipynb
+++ b/Exploring.ipynb
@@ -90,7 +90,7 @@
     "# Add an improved column\n",
     "humans['Education'] = (humans[\n",
     "    'Years of post-secondary education (e.g. BA=4; Ph.D.=10)']\n",
-    "                       .str.replace(r'.*=','')\n",
+    "                       .str.replace(r'.*=','',regex=True)\n",
     "                       .astype(int))\n",
     "\n",
     "# Then drop the one it is based on\n",


### PR DESCRIPTION
See https://pandas.pydata.org/docs/reference/api/pandas.Series.str.replace.html -- discovered when working the `Exploring.ipynb`.  Seems probably an API change to the Pandas `.str.replace()` default behavior?

Since the `.replace()` fails to have an affect on values like `BA=`, the subsequent `.astype(int)` raises exceptions on relevant values.

This change corrects the problem by forcing `regex=True`.